### PR TITLE
Tests without CHECK_NAMES=False and right aritmetic operation

### DIFF
--- a/nnodely/__init__.py
+++ b/nnodely/__init__.py
@@ -25,7 +25,7 @@ from nnodely.output import Output
 from nnodely.activation import Relu, ELU, Softmax, Sigmoid, Identity
 from nnodely.fir import Fir
 from nnodely.linear import Linear
-from nnodely.arithmetic import Add, Sum, Sub, Mul, Pow, Neg
+from nnodely.arithmetic import Add, Sum, Sub, Mul, Div, Pow, Neg
 from nnodely.trigonometric import Sin, Cos, Tan, Cosh, Tanh, Sech
 from nnodely.parametricfunction import ParamFun
 from nnodely.fuzzify import Fuzzify

--- a/nnodely/__init__.py
+++ b/nnodely/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 import sys
 major, minor = sys.version_info.major, sys.version_info.minor

--- a/nnodely/arithmetic.py
+++ b/nnodely/arithmetic.py
@@ -40,7 +40,7 @@ class Add(Stream, ToStream):
             >>> add = relation1 + relation2
     """
     @enforce_types
-    def __init__(self, obj1:Stream|Parameter|Constant, obj2:Stream|Parameter|Constant|int|float) -> Stream:
+    def __init__(self, obj1:Stream|Parameter|Constant|int|float, obj2:Stream|Parameter|Constant|int|float) -> Stream:
         obj1,obj2 = toStream(obj1),toStream(obj2)
         check(type(obj1) is Stream,TypeError,
               f"The type of {obj1} is {type(obj1)} and is not supported for add operation.")
@@ -68,7 +68,7 @@ class Sub(Stream, ToStream):
             >>> sub = relation1 - relation2
     """
     @enforce_types
-    def __init__(self, obj1:Stream|Parameter|Constant, obj2:Stream|Parameter|Constant|int|float) -> Stream:
+    def __init__(self, obj1:Stream|Parameter|Constant|int|float, obj2:Stream|Parameter|Constant|int|float) -> Stream:
         obj1, obj2 = toStream(obj1), toStream(obj2)
         check(type(obj1) is Stream,TypeError,
               f"The type of {obj1} is {type(obj1)} and is not supported for sub operation.")
@@ -95,7 +95,7 @@ class Mul(Stream, ToStream):
             >>> mul = relation1 * relation2
     """
     @enforce_types
-    def __init__(self, obj1:Stream|Parameter|Constant, obj2:Stream|Parameter|Constant|int|float) -> Stream:
+    def __init__(self, obj1:Stream|Parameter|Constant|int|float, obj2:Stream|Parameter|Constant|int|float) -> Stream:
         obj1, obj2 = toStream(obj1), toStream(obj2)
         check(type(obj1) is Stream, TypeError,
               f"The type of {obj1} is {type(obj1)} and is not supported for mul operation.")
@@ -122,7 +122,7 @@ class Div(Stream, ToStream):
             >>> div = relation1 / relation2
     """
     @enforce_types
-    def __init__(self, obj1:Stream|Parameter|Constant, obj2:Stream|Parameter|Constant|int|float) -> Stream:
+    def __init__(self, obj1:Stream|Parameter|Constant|int|float, obj2:Stream|Parameter|Constant|int|float) -> Stream:
         obj1, obj2 = toStream(obj1), toStream(obj2)
         check(type(obj1) is Stream, TypeError,
               f"The type of {obj1} is {type(obj1)} and is not supported for div operation.")
@@ -153,7 +153,7 @@ class Pow(Stream, ToStream):
             >>> pow = relation1 ** relation2
     """
     @enforce_types
-    def __init__(self, obj1:Stream|Parameter|Constant, obj2:Stream|Parameter|Constant|int|float) -> Stream:
+    def __init__(self, obj1:Stream|Parameter|Constant|int|float, obj2:Stream|Parameter|Constant|int|float) -> Stream:
         obj1, obj2 = toStream(obj1), toStream(obj2)
         check(type(obj1) is Stream, TypeError,
               f"The type of {obj1} is {type(obj1)} and is not supported for exp operation.")

--- a/nnodely/parameter.py
+++ b/nnodely/parameter.py
@@ -36,7 +36,32 @@ class Constant(NeuObj, Relation):
 
     Example
     -------
+    Example - passing a custom scalar value -> g.dim = {'dim': 1}:
+
         >>> g = Constant('gravity',values=9.81)
+
+    Example - passing a custom vector value -> n.dim = {'dim': 4}:
+
+        >>> n = Constant('numbers', values=[1,2,3,4])
+
+    Example - passing a custom vector value with single sample window -> n.dim = {'dim': 4, 'sw': 1}:
+
+        >>> n = Constant('numbers', values=[[1,2,3,4]])
+
+    Example - passing a custom vector value with double sample window -> n.dim = {'dim': 4, 'sw': 2}:
+
+        >>> n = Constant('numbers', values=[[2,3,4],[1,2,3]])
+
+    Example - passing a custom vector value with double sample window -> n.dim = {'dim': 4, 'sw': 2}.
+    If the value of the sw is differnt from the dimension of shape[0] an error will be raised.
+
+        >>> n = Constant('numbers', sw = 2, values=[[2,3,4],[1,2,3]])
+
+    Example - passing a custom vector value with time window -> n.dim = {'dim': 4, 'tw': 4}.
+    In this case the samplingtime must be 0.5 otherwise an error will be raised. If the Constant have a time dimension,
+    the input must have a len(shape) == 2.
+
+        >>> n = Constant('numbers', tw = 4, values=[[2,3,4],[1,2,3]])
     """
     @enforce_types
     def __init__(self, name:str,
@@ -196,10 +221,10 @@ class SampleTime():
     -------
         >>> dt = SampleTime()
     """
+    name = 'SampleTime'
+    g = Constant(name, values=0)
     def __new__(cls):
-        name = 'SampleTime'
-        g = Constant(name, values=0)
-        g.dim = {'dim': 1, 'sw': 1}
-        g.json['Constants'][name] = copy.deepcopy(g.dim)
-        g.json['Constants'][name]['values'] = name
-        return g
+        SampleTime.g.dim = {'dim': 1, 'sw': 1}
+        SampleTime.g.json['Constants'][SampleTime.name] = copy.deepcopy(SampleTime.g.dim)
+        SampleTime.g.json['Constants'][SampleTime.name]['values'] = SampleTime.name
+        return SampleTime.g

--- a/nnodely/relation.py
+++ b/nnodely/relation.py
@@ -52,7 +52,7 @@ class NeuObj():
         if name == '':
             name = 'Auto'+str(NeuObj.count)
         if CHECK_NAMES == True:
-            check(name not in NeuObj.names, NameError, f"The name {name} is already used change the name of NeuObj.")
+            check(name not in NeuObj.names, NameError, f"The name '{name}' is already used change the name of NeuObj.")
             check(name not in ForbiddenTags, NameError, f"The name '{name}' is a forbidden tag.")
             NeuObj.names.append(name)
         self.name = name
@@ -156,7 +156,7 @@ class Stream(Relation):
         from nnodely.input import State, Connect
         if type(tw) is list:
             check(0 >= tw[1] > tw[0] and tw[0] < 0, ValueError, "The dimension of the sample window must be in the past.")
-        s = State(self.name+"_state",dimensions=self.dim['dim'])
+        s = State(self.name+"_tw"+str(NeuObj.count),dimensions=self.dim['dim'])
         out_connect = Connect(self, s)
         win_state = s.tw(tw, offset)
         return Stream(win_state.name, merge(win_state.json, out_connect.json), win_state.dim,0 )
@@ -183,7 +183,7 @@ class Stream(Relation):
         from nnodely.input import State, Connect
         if type(sw) is list:
             check(0 >= sw[1] > sw[0] and sw[0] < 0, ValueError, "The dimension of the sample window must be in the past.")
-        s = State(self.name+"_state",dimensions=self.dim['dim'])
+        s = State(self.name+"_sw"+str(NeuObj.count),dimensions=self.dim['dim'])
         out_connect = Connect(self, s)
         win_state = s.sw(sw, offset)
         return Stream(win_state.name, merge(win_state.json, out_connect.json), win_state.dim,0 )

--- a/nnodely/relation.py
+++ b/nnodely/relation.py
@@ -67,21 +67,41 @@ class Relation():
         from nnodely.arithmetic import Add
         return Add(self, obj)
 
+    def __radd__(self, obj):
+        from nnodely.arithmetic import Add
+        return Add(obj, self)
+
     def __sub__(self, obj):
         from nnodely.arithmetic import Sub
         return Sub(self, obj)
+
+    def __rsub__(self, obj):
+        from nnodely.arithmetic import Sub
+        return Sub(obj, self)
 
     def __truediv__(self, obj):
         from nnodely.arithmetic import Div
         return Div(self, obj)
 
+    def __rtruediv__(self, obj):
+        from nnodely.arithmetic import Div
+        return Div(obj, self)
+
     def __mul__(self, obj):
         from nnodely.arithmetic import Mul
         return Mul(self, obj)
 
+    def __rmul__(self, obj):
+        from nnodely.arithmetic import Mul
+        return Mul(obj, self)
+
     def __pow__(self, obj):
         from nnodely.arithmetic import Pow
         return Pow(self, obj)
+
+    def __pow__(self, obj):
+        from nnodely.arithmetic import Pow
+        return Pow(obj, self)
 
     def __neg__(self):
         from nnodely.arithmetic import Neg
@@ -99,6 +119,20 @@ class Stream(Relation):
         self.name = name
         self.json = copy.deepcopy(json)
         self.dim = dim
+
+    def __str__(self):
+        from nnodely.visualizer.visualizer import color, GREEN
+        from pprint import pformat
+        stream = f" Stream "
+        stream_name = f" {self.name} {self.dim} "
+
+        title = color((stream).center(80, '='), GREEN, True)
+        json = color(pformat(self.json), GREEN)
+        stream = color((stream_name).center(80, '-'), GREEN, True)
+        return title + '\n' + json + '\n' + stream
+
+    def __repr__(self):
+        return self.__str__()
 
     @enforce_types
     def tw(self, tw:float|int|list, offset:float|int|None = None) -> "Stream":

--- a/nnodely/relation.py
+++ b/nnodely/relation.py
@@ -99,7 +99,7 @@ class Relation():
         from nnodely.arithmetic import Pow
         return Pow(self, obj)
 
-    def __pow__(self, obj):
+    def __rpow__(self, obj):
         from nnodely.arithmetic import Pow
         return Pow(obj, self)
 

--- a/nnodely/timeoperation.py
+++ b/nnodely/timeoperation.py
@@ -1,4 +1,4 @@
-from nnodely.relation import Stream, ToStream
+from nnodely.relation import Stream, NeuObj, ToStream
 from nnodely.utils import merge, enforce_types
 
 # Binary operators
@@ -17,10 +17,9 @@ class Integrate(Stream, ToStream):
     def __init__(self, obj:Stream, method:str = 'ForwardEuler') -> Stream:
         from nnodely.input import State, ClosedLoop
         from nnodely.parameter import SampleTime
-        s = State(obj.name + "_last", dimensions=obj.dim['dim'])
+        s = State(obj.name + "_int" + str(NeuObj.count), dimensions=obj.dim['dim'])
         if method == 'ForwardEuler':
-            DT = SampleTime()
-            new_s = s.last()  + obj * DT
+            new_s = s.last()  + obj * SampleTime()
         else:
             raise ValueError(f"The method '{method}' is not supported yet")
         out_connect = ClosedLoop(new_s, s)
@@ -38,10 +37,9 @@ class Derivate(Stream, ToStream):
     def __init__(self, obj:Stream, method:str = 'ForwardEuler') -> Stream:
         from nnodely.input import State, ClosedLoop
         from nnodely.parameter import SampleTime
-        s = State(obj.name + "_last", dimensions=obj.dim['dim'])
+        s = State(obj.name + "_der" + str(NeuObj.count), dimensions=obj.dim['dim'])
         if method == 'ForwardEuler':
-            DT = SampleTime()
-            new_s = (obj - s.last()) / DT
+            new_s = (obj - s.last()) / SampleTime()
         else:
             raise ValueError(f"The method '{method}' is not supported yet")
         out_connect = ClosedLoop(obj, s)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,10 +2,9 @@ import sys, os, unittest
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -22,6 +21,7 @@ test_folder = os.path.join(os.path.dirname(__file__), 'test_data/')
 class ModelyCreateDatasetTest(unittest.TestCase):
     
     def test_build_dataset_simple(self):
+        NeuObj.clearNames()
         input = Input('in1')
         output = Input('out')
         relation = Fir(input.tw(0.05))
@@ -40,6 +40,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]], [[1.2]]], test.data['dataset_1']['out'].tolist())
 
     def test_build_multi_dataset_simple(self):
+        NeuObj.clearNames()
         input = Input('in1')
         output = Input('out')
         relation = Fir(input.tw(0.05))
@@ -74,6 +75,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[3.225]], [[3.224]], [[3.222]], [[3.22]], [[3.217]], [[3.214]], [[3.211]], [[3.207]]], test.data['test_dataset']['out'].tolist())
     
     def test_build_dataset_medium1(self):
+        NeuObj.clearNames()
         input = Input('in1')
         output = Input('out')
         rel1 = Fir(input.tw(0.05))
@@ -92,6 +94,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]], [[1.2]]],test.data['dataset']['out'].tolist())
     
     def test_build_multi_dataset_medium1(self):
+        NeuObj.clearNames()
         input = Input('in1')
         output = Input('out')
         rel1 = Fir(input.tw(0.05))
@@ -124,6 +127,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[3.225]], [[3.224]], [[3.222]], [[3.22]], [[3.217]], [[3.214]], [[3.211]], [[3.207]]],test.data['test_dataset']['out'].tolist())
     
     def test_build_dataset_medium2(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         input2 = Input('in2')
         output = Input('out')
@@ -147,6 +151,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]], [[1.2]]],test.data['dataset']['out'].tolist())
     
     def test_build_dataset_complex1(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -165,6 +170,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]]],test.data['dataset']['out'].tolist())
 
     def test_build_multi_dataset_complex1(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -197,6 +203,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[3.225]], [[3.224]], [[3.222]], [[3.22]], [[3.217]], [[3.214]], [[3.211]]],test.data['test_dataset']['out'].tolist())
     
     def test_build_dataset_complex2(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -215,6 +222,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]], [[1.2]]],test.data['dataset']['out'].tolist())
     
     def test_build_dataset_complex3(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         input2 = Input('in2')
         output = Input('out')
@@ -222,7 +230,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         rel2 = Fir(input2.tw(0.02))
         rel3 = Fir(input1.tw([-0.01,0.01]))
         rel4 = Fir(input2.last())
-        fun = Output('out',rel1+rel2+rel3+rel4)
+        fun = Output('out-net',rel1+rel2+rel3+rel4)
 
         test = Modely(visualizer=None)
         test.addModel('fun', fun)
@@ -241,6 +249,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]], [[1.2]]],test.data['dataset']['out'].tolist())
 
     def test_build_multi_dataset_complex3(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         input2 = Input('in2')
         output = Input('out')
@@ -248,7 +257,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         rel2 = Fir(input2.tw(0.02))
         rel3 = Fir(input1.tw([-0.01,0.01]))
         rel4 = Fir(input2.last())
-        fun = Output('out',rel1+rel2+rel3+rel4)
+        fun = Output('out-net',rel1+rel2+rel3+rel4)
 
         test = Modely(visualizer=None)
         test.addModel('fun',fun)
@@ -284,12 +293,13 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[3.225]], [[3.224]], [[3.222]], [[3.22]], [[3.217]], [[3.214]], [[3.211]], [[3.207]]],test.data['test_dataset']['out'].tolist())
     
     def test_build_dataset_complex5(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
         rel2 = Fir(input1.tw([-0.01,0.01]))
         rel3 = Fir(input1.tw([-0.02,0.02]))
-        fun = Output('out',rel1+rel2+rel3)
+        fun = Output('out-net',rel1+rel2+rel3)
 
         test = Modely(visualizer=None)
         test.addModel('fun', fun)
@@ -305,12 +315,13 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]]],test.data['dataset']['out'].tolist())
     
     def test_build_dataset_complex6(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
         rel2 = Fir(input1.tw([-0.01,0.02]))
         rel3 = Fir(input1.tw([-0.05,0.01]))
-        fun = Output('out',rel1+rel2+rel3)
+        fun = Output('out-net',rel1+rel2+rel3)
 
         test = Modely(visualizer=None)
         test.addModel('fun',fun)
@@ -326,12 +337,13 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[1.225]], [[1.224]], [[1.222]], [[1.22]], [[1.217]], [[1.214]], [[1.211]], [[1.207]], [[1.204]]],test.data['dataset']['out'].tolist())
 
     def test_build_dataset_custom(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
         rel2 = Fir(input1.tw([-0.01,0.02]))
         rel3 = Fir(input1.tw([-0.05,0.01]))
-        fun = Output('out',rel1+rel2+rel3)
+        fun = Output('out-net',rel1+rel2+rel3)
 
         test = Modely(visualizer=None)
         test.addModel('fun',fun)
@@ -355,12 +367,13 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[7]],[[9]],[[11]],[[13]]],test.data['dataset']['out'].tolist())
 
     def test_build_multi_dataset_custom(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
         rel2 = Fir(input1.tw([-0.01, 0.02]))
         rel3 = Fir(input1.tw([-0.05, 0.01]))
-        fun = Output('out', rel1 + rel2 + rel3)
+        fun = Output('out-net', rel1 + rel2 + rel3)
 
         test = Modely(visualizer=None)
         test.addModel('fun',fun)
@@ -409,6 +422,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertEqual([[[47]], [[49]], [[51]], [[53]]], test.data['test_dataset']['out'].tolist())
 
     def test_vector_input_dataset(self):
+        NeuObj.clearNames()
         x = Input('x', dimensions=4)
         y = Input('y', dimensions=3)
         k = Input('k', dimensions=2)
@@ -482,6 +496,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
                          test.data['dataset']['w'][-2].tolist())
 
     def test_vector_input_dataset_files(self):
+        NeuObj.clearNames()
         x = Input('x', dimensions=4)
         y = Input('y', dimensions=3)
         k = Input('k', dimensions=2)
@@ -545,6 +560,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         #                 training_params={'num_of_epochs': 100, 'train_batch_size': 4, 'test_batch_size': 4})
     
     def test_multifiles(self):
+        NeuObj.clearNames()
         x = State('x')
         relation = Fir()(x.tw(0.05))
         output = Output('out', relation)
@@ -564,6 +580,7 @@ class ModelyCreateDatasetTest(unittest.TestCase):
         self.assertListEqual(test.multifile['dataset'], [5, 20, 45])
 
     def test_multifiles_2(self):
+        NeuObj.clearNames()
         x = State('x')
         y = Input('y')
         relation = Fir()(x.tw(0.05))+Fir(y.sw([-2,2]))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,16 +1,10 @@
-import sys, os, unittest, torch, shutil
+import  os, unittest, torch, shutil
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
-import torch.onnx
-import onnx
-import onnxruntime as ort
-import importlib
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -30,6 +24,7 @@ class ModelyExportTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(ModelyExportTest, self).__init__(*args, **kwargs)
+        NeuObj.clearNames()
 
         self.result_path = './results'
         self.test = Modely(visualizer=None, seed=42, workspace=self.result_path)
@@ -74,7 +69,7 @@ class ModelyExportTest(unittest.TestCase):
         out6 = Output('out6', LocalModel(output_function=Fir())(x.tw(1), fuzzy))
         with self.assertRaises(TypeError):
             parfun_z(x.tw(5), t_5, c_5)
-        out7 = Output('out', Fir(parfun_x(x.tw(1)) + parfun_y(y.tw(1), c_v)) + Fir(parfun_z(x.tw(5), t_5, c_5_2)))
+        out7 = Output('out7', Fir(parfun_x(x.tw(1)) + parfun_y(y.tw(1), c_v)) + Fir(parfun_z(x.tw(5), t_5, c_5_2)))
 
         self.test.addModel('modelA', out)
         self.test.addModel('modelB', [out2, out3, out4])

--- a/tests/test_input_dimensions.py
+++ b/tests/test_input_dimensions.py
@@ -1,9 +1,7 @@
 import unittest, sys, os, torch
-
-from nnodely import *
-
 import numpy as np
 
+from nnodely import *
 from nnodely.logger import logging, nnLogger
 from nnodely.relation import NeuObj
 
@@ -383,7 +381,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         out6 = Output('out6', LocalModel(output_function=Fir())(x.tw(1), fuzzy))
         with self.assertRaises(TypeError):
             parfun_z(x.tw(5), t_5, c_5)
-        out7 = Output('out', Fir(parfun_x(x.tw(1)) + parfun_y(y.tw(1), c_v)) + Fir(parfun_z(x.tw(5), t_5, c_5_2)))
+        out7 = Output('out7', Fir(parfun_x(x.tw(1)) + parfun_y(y.tw(1), c_v)) + Fir(parfun_z(x.tw(5), t_5, c_5_2)))
 
         # parfun = ParamFun(myFun, map_over_batch=True)
         # p = Constant('co', values=[[2]])

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,10 +4,8 @@ import numpy as np
 
 from nnodely import *
 from nnodely.relation import NeuObj, Stream
-from nnodely import relation
-relation.CHECK_NAMES = False
-
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -67,25 +65,26 @@ class ModelyJsonTest(unittest.TestCase):
         self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in1': {'dim': 1, 'tw': [-1,0], 'sw': [0, 0]}},'Functions' : {}, 'Parameters' : {}, 'Outputs': {}, 'States': {}, 'Relations': {'Sub17': ['Sub', ['TimePart14', 'TimePart16']],
                'TimePart14': ['TimePart', ['in1'], -1, [-1, 0]],
                'TimePart16': ['TimePart', ['in1'], -1, [-1, 0]]}},out.json)
-        input = Input('in1', dimensions = 5)
+        input = Input('in2', dimensions = 5)
         inlast = input.last()
         out = inlast + inlast
-        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in1': {'dim': 5, 'tw': [0,0], 'sw': [-1, 0]}},'Functions' : {}, 'Parameters' : {}, 'Outputs': {}, 'States': {}, 'Relations': {'Add20': ['Add', ['SamplePart19', 'SamplePart19']],
-               'SamplePart19': ['SamplePart', ['in1'], -1, [-1, 0]]}},out.json)
+        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in2': {'dim': 5, 'tw': [0,0], 'sw': [-1, 0]}},'Functions' : {}, 'Parameters' : {}, 'Outputs': {}, 'States': {}, 'Relations': {'Add20': ['Add', ['SamplePart19', 'SamplePart19']],
+               'SamplePart19': ['SamplePart', ['in2'], -1, [-1, 0]]}},out.json)
         out = input.tw(1) + input.tw(1)
-        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in1': {'dim': 5, 'tw': [-1, 0], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add25': ['Add', ['TimePart22', 'TimePart24']],
-               'TimePart22': ['TimePart', ['in1'], -1, [-1, 0]],
-               'TimePart24': ['TimePart', ['in1'], -1, [-1, 0]]}}, out.json)
+        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in2': {'dim': 5, 'tw': [-1, 0], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add25': ['Add', ['TimePart22', 'TimePart24']],
+               'TimePart22': ['TimePart', ['in2'], -1, [-1, 0]],
+               'TimePart24': ['TimePart', ['in2'], -1, [-1, 0]]}}, out.json)
         out = input.tw([2,5]) + input.tw([3,6])
-        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in1': {'dim': 5, 'tw': [2, 6], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add30': ['Add', ['TimePart27', 'TimePart29']],
-               'TimePart27': ['TimePart', ['in1'], -1, [2, 5]],
-               'TimePart29': ['TimePart', ['in1'], -1, [3, 6]]}}, out.json)
+        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in2': {'dim': 5, 'tw': [2, 6], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add30': ['Add', ['TimePart27', 'TimePart29']],
+               'TimePart27': ['TimePart', ['in2'], -1, [2, 5]],
+               'TimePart29': ['TimePart', ['in2'], -1, [3, 6]]}}, out.json)
         out = input.tw([-5,-2]) + input.tw([-6,-3])
-        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in1': {'dim': 5, 'tw': [-6, -2], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add35': ['Add', ['TimePart32', 'TimePart34']],
-               'TimePart32': ['TimePart', ['in1'], -1, [-5, -2]],
-               'TimePart34': ['TimePart', ['in1'], -1, [-6, -3]]}}, out.json)
+        self.assertEqual({'Info':{},'Constants': {},'Inputs': {'in2': {'dim': 5, 'tw': [-6, -2], 'sw': [0, 0]}}, 'Functions': {}, 'Parameters': {},'Outputs': {}, 'States': {}, 'Relations': {'Add35': ['Add', ['TimePart32', 'TimePart34']],
+               'TimePart32': ['TimePart', ['in2'], -1, [-5, -2]],
+               'TimePart34': ['TimePart', ['in2'], -1, [-6, -3]]}}, out.json)
 
     def test_scalar_input_dimensions(self):
+        NeuObj.clearNames()
         input = Input('in1').last()
         out = input+input
         self.assertEqual({'dim': 1,'sw': 1}, out.dim)
@@ -121,6 +120,7 @@ class ModelyJsonTest(unittest.TestCase):
             out = TimePart(inpart,-1,0)
 
     def test_scalar_input_tw_dimensions(self):
+        NeuObj.clearNames()
         input = Input('in1')
         out = input.tw(1) + input.tw(1)
         self.assertEqual({'dim': 1, 'tw': 1}, out.dim)
@@ -164,6 +164,7 @@ class ModelyJsonTest(unittest.TestCase):
         self.assertEqual({'dim': 1, 'tw': 1}, out.dim)
 
     def test_scalar_input_tw2_dimensions(self):
+        NeuObj.clearNames()
         input = Input('in1')
         out = input.tw([-1,1])+input.tw([-2,0])
         self.assertEqual({'dim': 1, 'tw': 2}, out.dim)
@@ -179,6 +180,7 @@ class ModelyJsonTest(unittest.TestCase):
              out = input.tw([-2,0])+input.tw([-1,0])
 
     def test_scalar_input_sw_dimensions(self):
+        NeuObj.clearNames()
         input = Input('in1')
         out = input.sw([-1,1])+input.sw([-2,0])
         self.assertEqual({'dim': 1, 'sw': 2}, out.dim)
@@ -200,6 +202,7 @@ class ModelyJsonTest(unittest.TestCase):
             out = input.sw([-1.2,0.05])
 
     def test_vector_input_dimensions(self):
+        NeuObj.clearNames()
         input = Input('in1', dimensions = 5)
         self.assertEqual({'dim': 5}, input.dim)
         self.assertEqual({'dim': 5, 'tw' : 2}, input.tw(2).dim)
@@ -219,12 +222,13 @@ class ModelyJsonTest(unittest.TestCase):
         self.assertEqual({'dim': 5, 'tw': 2}, out.dim)
 
     def test_parameter_and_linear(self):
+        NeuObj.clearNames()
         input = Input('in1').last()
         W15 = Parameter('W15', dimensions=(1, 5))
         b15 = Parameter('b15', dimensions=5)
         input4 = Input('in4',dimensions=4).last()
         W45 = Parameter('W45', dimensions=(4, 5))
-        b45 = Parameter('b15', dimensions=5)
+        b45 = Parameter('b45', dimensions=5)
 
         out = Linear(input) + Linear(input4)
         out3 = Linear(3)(input) + Linear(3)(input4)
@@ -235,6 +239,7 @@ class ModelyJsonTest(unittest.TestCase):
         self.assertEqual({'dim': 5, 'sw': 1}, outW.dim)
         self.assertEqual({'dim': 5, 'sw': 1}, outWb.dim)
 
+        NeuObj.clearNames()
         input2 = Input('in1').sw([-1,1])
         W15 = Parameter('W15', dimensions=(1, 5))
         b15 = Parameter('b15', dimensions=5)
@@ -261,6 +266,7 @@ class ModelyJsonTest(unittest.TestCase):
             Linear(W = W15,b = b15)(input2) + Linear(W = W45, b = b45)(input4)
 
     def test_input_paramfun_param_const(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         def fun_test(x,y,z,k):
             return x*y*z*k
@@ -372,6 +378,7 @@ class ModelyJsonTest(unittest.TestCase):
         self.assertEqual(['TimePart1', 'll', 'oo', 'pp'], out.json['Relations']['ParamFun2'][1])
 
     def test_check_multiple_streams_compatibility_paramfun(self):
+        NeuObj.clearNames()
         log.setAllLevel(logging.WARNING)
         x = Input('x')
         F = Input('F')
@@ -427,6 +434,7 @@ class ModelyJsonTest(unittest.TestCase):
         log.setAllLevel(logging.CRITICAL)
 
     def test_check_multiple_streams_compatibility_linear(self):
+        NeuObj.clearNames()
         log.setAllLevel(logging.WARNING)
         x = Input('x',dimensions=3)
         f = Input('f')
@@ -460,6 +468,7 @@ class ModelyJsonTest(unittest.TestCase):
         log.setAllLevel(logging.CRITICAL)
 
     def test_check_multiple_streams_compatibility_fir(self):
+        NeuObj.clearNames()
         log.setAllLevel(logging.WARNING)
         x = Input('x')
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -2,10 +2,9 @@ import unittest, os, sys
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -28,6 +27,7 @@ class ModelyTrainingTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_losses_compare(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         target1 = Input('out1')
         target2 = Input('out2')
@@ -73,6 +73,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.TestAlmostEqual(test.performance['test_dataset_0.10']['error2']['mse'], test.training['error2']['val'][-1])
 
     def test_losses_compare_closed_loop_state(self):
+        NeuObj.clearNames()
         input1 = State('in1')
         target1 = Input('out1')
         target2 = Input('out2')
@@ -136,6 +137,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.TestAlmostEqual(test.performance['validation_dataset_0.50']['error2']['mse'], test.training['error2']['val'][-1])
 
     def test_losses_compare_closed_loop(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         target1 = Input('out1')
         target2 = Input('out2')

--- a/tests/test_model_predict.py
+++ b/tests/test_model_predict.py
@@ -711,6 +711,13 @@ class ModelyPredictTest(unittest.TestCase):
         tanh1 = Tanh(par) + Tanh(5.2)
         tot1 = add + sub + mul + div + pow + sin1 + cos1 + tan1 + relu1 + tanh1
 
+        add = 5.2 + in1 + (3 + par)
+        sub = - 5.2 - par + (3 - in1)
+        mul = 5.2 * in1 * (2 * par)
+        div = 5.2 / in1 / (3 / par)
+        pow = (0.2 ** in1) + (2 ** par)
+        tot11 = add + sub + mul + div + pow
+
         add4 = in4 + par4 + 5.2
         sub4 = in4 - par4 - 5.2
         mul4 = in4 * par4 * 5.2
@@ -722,12 +729,23 @@ class ModelyPredictTest(unittest.TestCase):
         relu4 = Relu(par4) + Relu(5.2)
         tanh4 = Tanh(par4) + Tanh(5.2)
         tot4 = add4 + sub4 + mul4 + div4 + pow4 + sin4 + cos4 + tan4 + relu4 + tanh4
+
+        add4 = 5.2 + in4 + (3 + par4)
+        sub4 = - 5.2 - par4 + (3 - in4)
+        mul4 = 5.2 * in4 * (2 * par4)
+        div4 = 5.2 / in4 / (3 / par4)
+        pow4 = (0.2 ** in4) + (2 ** par4)
+        tot41 = add4 + sub4 + mul4 + div4 + pow4
+
         out1 = Output('out1', tot1)
+        out11 = Output('out11', tot11)
         out4 = Output('out4', tot4)
+        out41 = Output('out41', tot41)
+
         linW = Parameter('linW',dimensions=(4,1),values=[[[1],[1],[1],[1]]])
         outtot = Output('outtot', tot1 + Linear(W=linW)(tot4))
         test = Modely(visualizer=None)
-        test.addModel('out',[out1,out4,outtot])
+        test.addModel('out',[out1,out4,outtot,out11,out41])
         test.neuralizeModel()
 
         results = test({'in1': [1, 2, -2],'in4': [[6, 2, 2, 4], [7, 2, 2, 4], [-6, -5, 5, 4]]})
@@ -738,6 +756,14 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([34.8819529, 33554496.0,  -33554480.0], results['out1'] )
         self.TestAlmostEqual([[[58.9539756, 46.1638031, 554.231201171875, 4294967296.0]], [[67.3462829589843, 46.16380310058594, 554.231201171875, 4294967296.0]], [[ -41.75371170043945, 567.6907348632812, 1953220.375, 4294967296.0]]], results['out4'])
         self.TestAlmostEqual([4294967808.0, 4328522240.0,  4263366656.0], results['outtot'])
+
+        self.assertEqual((3,), np.array(results['out11']).shape)
+        self.assertEqual((3,1,4), np.array(results['out41']).shape)
+
+        self.TestAlmostEqual([98.86666667, 146.37333333, -45.33333333], results['out11'])
+        self.TestAlmostEqual([[[   70.68895289,    53.37333333,    79.04      ,   190.13493333]],
+                                   [[   81.04763185,    53.37333333,    79.04      ,   190.13493333]],
+                                   [[15570.31111111,  3030.30666667,   171.04032   ,   190.13493333]]], results['out41'],precision=2)
 
     def test_check_modify_stream(self):
         torch.manual_seed(1)

--- a/tests/test_model_predict.py
+++ b/tests/test_model_predict.py
@@ -3,10 +3,8 @@ import numpy as np
 
 from nnodely import *
 from nnodely.relation import NeuObj
-from nnodely import relation
-relation.CHECK_NAMES = False
-
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -44,7 +42,7 @@ class ModelyPredictTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_single_in(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         out_fun = Fir(in1.tw(0.1)) + Fir(in2.last())
@@ -63,7 +61,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([33.74938201904297, 40.309326171875, 46.86927032470703], results['out'])
 
     def test_activation(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         in1 = Input('in1')
         out_fun = ELU(in1.last()) + Relu(in1.last()) + Tanh(in1.last())
         out = Output('out', out_fun)
@@ -75,6 +73,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([-1.3937146663665771,-0.8555865287780762,0,0.5973753333091736,4.964027404785156,21.0], results['out'])
 
     def test_single_in_window(self):
+        NeuObj.clearNames()
         # Here there is more sample for each time step but the dimensions of the input is 1
         in1 = Input('in1')
 
@@ -139,6 +138,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([1],results['x.sw([0,1])'])
     
     def test_single_in_window_offset(self):
+        NeuObj.clearNames()
         # Here there is more sample for each time step but the dimensions of the input is 1
         in1 = Input('in1')
 
@@ -183,6 +183,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[-2,-1,0,1,7,3]],results['x.sw([-3, 3])-2'])
     
     def test_multi_in_window_offset(self):
+        NeuObj.clearNames()
         # Here there is more sample for each time step but the dimensions of the input is 1
         in1 = Input('in1',dimensions=3)
 
@@ -238,6 +239,7 @@ class ModelyPredictTest(unittest.TestCase):
                                     [[-2,0,-1],[-1,-2,-3],[0,0,0],[1,5,0],[2,1,0],[1,0,-1]]], results['x.sw([-3, 3])-2'])
     
     def test_single_in_window_offset_aritmetic(self):
+        NeuObj.clearNames()
         # Elementwise arithmetic, Activation, Trigonometric
         # the dimensions and time window remain unchanged, for the
         # binary operators must be equal
@@ -299,10 +301,10 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[[1, 2], [0, 0], [1, 6], [4, 0]],[[0, -15], [0, 0], [2, -21], [6, 6]]], results['mul2'])
     
     def test_single_in_window_offset_fir(self):
+        NeuObj.clearNames()
         # The input must be scalar and the time dimension is compress to 1,
         # Vector input not allowed, it could be done that a number of fir filters equal to the size of the vector are constructed
         # Should weights be shared or not?
-        torch.manual_seed(1)
         in1 = Input('in1')
         out1 = Output('Fir3', Fir(3)(in1.last()))
         out2 = Output('Fir5', Fir(5)(in1.tw(1)))#
@@ -338,6 +340,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((3,1,6), np.array(results['Fir6']).shape)
     
     def test_fir_and_parameter(self):
+        NeuObj.clearNames()
         x = Input('x')
         p1 = Parameter('p1', tw=3, values=[[1],[2],[3],[6],[2],[3]])
         with self.assertRaises(TypeError):
@@ -389,6 +392,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[[2.0, 0.0]], [[2.0, 1.0]]], results['out5'])
     
     def test_single_in_window_offset_parametric_function(self):
+        NeuObj.clearNames()
         # An input dimension is temporal and does not remain unchanged unless redefined on output
         # If there are multiple inputs the function returns an error if the dimensions are not defined
         in1 = Input('in1')
@@ -409,6 +413,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((2,), np.array(results['out']).shape)
         self.TestAlmostEqual(results['out'],[0.7576315999031067,1.5152631998062134])
 
+        NeuObj.clearNames('out')
         out = Output('out', ParamFun(myfun)(in1.tw(0.2)))
         test = Modely(visualizer=None, seed = 1)
         test.addModel('out',out)
@@ -431,7 +436,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((4,2), np.array(results['out']).shape)
         self.TestAlmostEqual(results['out'], [[0.7576315999031067, 1.5152631998062134], [1.5152631998062134, 2.272894859313965], [2.272894859313965, 3.0305263996124268], [3.0305263996124268, 3.7881579399108887]])
 
-        out = Output('out', ParamFun(myfun)(in1.last(),in1.last()))
+        out = Output('out2', ParamFun(myfun)(in1.last(),in1.last()))
         test = Modely(visualizer=None, seed = 1)
         test.addModel('out',out)
         test.neuralizeModel(0.1)
@@ -439,13 +444,13 @@ class ModelyPredictTest(unittest.TestCase):
         #results = test({'in1': 1})
         #self.TestAlmostEqual(results['out'],[1])
         results = test({'in1': [1]})
-        self.TestAlmostEqual(results['out'],[1])
+        self.TestAlmostEqual(results['out2'],[1])
         results = test({'in1': [2]})
-        self.TestAlmostEqual(results['out'],[4])
+        self.TestAlmostEqual(results['out2'],[4])
         results = test({'in1': [1,2]})
-        self.TestAlmostEqual(results['out'],[1,4])
+        self.TestAlmostEqual(results['out2'],[1,4])
 
-        out = Output('out', ParamFun(myfun)(in1.tw(0.1), in1.tw(0.1)))
+        out = Output('out3', ParamFun(myfun)(in1.tw(0.1), in1.tw(0.1)))
         test = Modely(visualizer=None)
         test.addModel('out',out)
         test.neuralizeModel(0.1)
@@ -453,23 +458,23 @@ class ModelyPredictTest(unittest.TestCase):
         #results = test({'in1': 2})
         #self.TestAlmostEqual(results['out'], [4])
         results = test({'in1': [2]})
-        self.TestAlmostEqual(results['out'], [4])
+        self.TestAlmostEqual(results['out3'], [4])
         results = test({'in1': [2,1]})
-        self.TestAlmostEqual(results['out'], [4,1])
+        self.TestAlmostEqual(results['out3'], [4,1])
 
-        out = Output('out', ParamFun(myfun)(in1.tw(0.2), in1.tw(0.2)))
+        out = Output('out4', ParamFun(myfun)(in1.tw(0.2), in1.tw(0.2)))
         test = Modely(visualizer=None)
         test.addModel('out',out)
         test.neuralizeModel(0.1)
 
         results = test({'in1': [2,4]})
-        self.assertEqual((1,2), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[4,16]])
+        self.assertEqual((1,2), np.array(results['out4']).shape)
+        self.TestAlmostEqual(results['out4'], [[4,16]])
         results = test({'in1': [[1, 2], [3, 2]]}, sampled=True)
-        self.assertEqual((2,2), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[1.0, 4.0], [9.0, 4.0]])
+        self.assertEqual((2,2), np.array(results['out4']).shape)
+        self.TestAlmostEqual(results['out4'], [[1.0, 4.0], [9.0, 4.0]])
 
-        out = Output('out', ParamFun(myfun)(in1.tw(0.3), in1.tw(0.3)))
+        out = Output('out5', ParamFun(myfun)(in1.tw(0.3), in1.tw(0.3)))
         test = Modely(visualizer=None)
         test.addModel('out',out)
         test.neuralizeModel(0.1)
@@ -481,19 +486,19 @@ class ModelyPredictTest(unittest.TestCase):
             test({'in1': [2, 4]})
 
         results = test({'in1': [3,2,1]})
-        self.assertEqual((1,3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[9,4,1]])
+        self.assertEqual((1,3), np.array(results['out5']).shape)
+        self.TestAlmostEqual(results['out5'], [[9,4,1]])
         results = test({'in1': [[1,2,2],[3,4,5]]}, sampled=True)
-        self.assertEqual((2,3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[1, 4, 4], [9, 16, 25]])
+        self.assertEqual((2,3), np.array(results['out5']).shape)
+        self.TestAlmostEqual(results['out5'], [[1, 4, 4], [9, 16, 25]])
         results = test({'in1': [[3, 2, 1], [2, 1, 0]]}, sampled=True)
-        self.assertEqual((2,3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[9, 4, 1],[4, 1, 0]])
+        self.assertEqual((2,3), np.array(results['out5']).shape)
+        self.TestAlmostEqual(results['out5'], [[9, 4, 1],[4, 1, 0]])
         results = test({'in1': [3,2,1,0]})
-        self.assertEqual((2,3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[9, 4, 1],[4, 1, 0]])
+        self.assertEqual((2,3), np.array(results['out5']).shape)
+        self.TestAlmostEqual(results['out5'], [[9, 4, 1],[4, 1, 0]])
         
-        out = Output('out', ParamFun(myfun)(in1.tw(0.4), in1.tw(0.4)))
+        out = Output('out6', ParamFun(myfun)(in1.tw(0.4), in1.tw(0.4)))
         test = Modely(visualizer=None)
         test.addModel('out',out)
         test.neuralizeModel(0.1)
@@ -501,6 +506,7 @@ class ModelyPredictTest(unittest.TestCase):
             test({'in1': [[1, 2, 2], [3, 4, 5]]})
     
     def test_vectorial_input_parametric_function(self):
+        NeuObj.clearNames()
         # Vector input for parametric function
         in1 = Input('in1', dimensions=3)
         in2 = Input('in2', dimensions=2)
@@ -521,6 +527,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual(results['out'], [[23,52,81],[41,94,147]])
     
     def test_parametric_function_and_fir(self):
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         out = Output('out', Fir(ParamFun(myfun2)(in1.tw(0.4))))
@@ -540,6 +547,7 @@ class ModelyPredictTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Output('out', Fir(ParamFun(myfun2)(in1.tw(0.4),in2.tw(0.2))))
 
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         out = Output('out', Fir(ParamFun(myfun2)(in1.tw(0.4),in2.tw(0.4))))
@@ -569,6 +577,7 @@ class ModelyPredictTest(unittest.TestCase):
         results = test({'in1': [[1, 2, 2, 4], [1, 2, 2, 4]], 'in2': [[1, 2, 2, 4], [5, 5, 5, 5]]}, sampled=True)
         self.TestAlmostEqual(results['out'], [-0.4379930794239044, 0.5163354873657227])
 
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         out = Output('out', Fir(3)(ParamFun(myfun2)(in1.tw(0.4), in2.tw(0.4))))
@@ -580,6 +589,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((2,1,3), np.array(results['out']).shape)
         self.TestAlmostEqual(results['out'], [[[0.22182656824588776, -0.11421152949333191, 0.5385046601295471]], [[0.22182656824588776, -0.11421152949333191,  0.5385046601295471]]])
 
+        NeuObj.clearNames('out')
         parfun = ParamFun(myfun2)
         with self.assertRaises(TypeError):
             Output('out', parfun(Fir(3)(parfun(in1.tw(0.4), in2.tw(0.4)))))
@@ -602,6 +612,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual(results['out'], [[[0.2126065045595169, 0.21099068224430084, 0.20540902018547058]], [[0.1667831689119339, 0.16757671535015106,0.1605043113231659]]])
 
     def test_parametric_function_and_fir_with_parameters(self):
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         k1 = Parameter('k1', dimensions=1, tw=0.4, values=[[1.0], [1.0], [1.0], [1.0]])
@@ -623,6 +634,7 @@ class ModelyPredictTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Output('out', Fir(ParamFun(myfun2)(in1.tw(0.4), in2.tw(0.2))))
 
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         k1 = Parameter('k1', dimensions=1, tw=0.4, values=[[1.0], [1.0], [1.0], [1.0]])
@@ -654,6 +666,7 @@ class ModelyPredictTest(unittest.TestCase):
         results = test({'in1': [[1, 2, 2, 4], [1, 2, 2, 4]], 'in2': [[1, 2, 2, 4], [5, 5, 5, 5]]}, sampled=True)
         self.TestAlmostEqual(results['out'], [0.3850506544113159, 1.446676254272461])
 
+        NeuObj.clearNames()
         in1 = Input('in1')
         in2 = Input('in2')
         k1 = Parameter('k1', dimensions=1, tw=0.4, values=[[1.0], [1.0], [1.0], [1.0]])
@@ -674,27 +687,27 @@ class ModelyPredictTest(unittest.TestCase):
             Output('out', parfun(Fir(3)(parfun(in1.tw(0.4), in2.tw(0.4)))))
 
         parfun = ParamFun(myfun2)
-        out = Output('out', parfun(Fir(3)(parfun(in1.tw(0.4)))))
+        out = Output('out2', parfun(Fir(3)(parfun(in1.tw(0.4)))))
         test = Modely(visualizer=None, seed=42)
         test.addModel('out', out)
         test.neuralizeModel(0.1)
 
         results = test({'in1': [[1, 2, 2, 4], [2, 1, 1, 3]]}, sampled=True)
-        self.assertEqual((2, 1, 3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
+        self.assertEqual((2, 1, 3), np.array(results['out2']).shape)
+        self.TestAlmostEqual(results['out2'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
                                               [[0.8505557179450989, 0.7224123477935791, 0.77630215883255]]])
 
         results = test({'in1': [1, 2, 2, 4, 3], 'in2': [6, 2, 2, 4, 4]})
-        self.assertEqual((2, 1, 3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
+        self.assertEqual((2, 1, 3), np.array(results['out2']).shape)
+        self.TestAlmostEqual(results['out2'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
                                               [[-0.09300854057073593, 0.44719645380973816, -0.03044888749718666]]])
         results = test({'in1': [[1, 2, 2, 4], [2, 2, 4, 3]], 'in2': [[6, 2, 2, 4], [2, 2, 4, 4]]}, sampled=True)
-        self.assertEqual((2, 1, 3), np.array(results['out']).shape)
-        self.TestAlmostEqual(results['out'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
+        self.assertEqual((2, 1, 3), np.array(results['out2']).shape)
+        self.TestAlmostEqual(results['out2'], [[[0.790096640586853, 0.7821592688560486, 0.8219361901283264]],
                                               [[-0.09300854057073593, 0.44719645380973816, -0.03044888749718666]]])
 
     def test_trigonometri_parameter_and_numeric_constant(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         in1 = Input('in1').last()
         par = Parameter('par', values=[[5]])
         in4 = Input('in4', dimensions=4).last()
@@ -744,7 +757,7 @@ class ModelyPredictTest(unittest.TestCase):
 
         linW = Parameter('linW',dimensions=(4,1),values=[[[1],[1],[1],[1]]])
         outtot = Output('outtot', tot1 + Linear(W=linW)(tot4))
-        test = Modely(visualizer=None)
+        test = Modely(visualizer=None, seed=1)
         test.addModel('out',[out1,out4,outtot,out11,out41])
         test.neuralizeModel()
 
@@ -766,7 +779,7 @@ class ModelyPredictTest(unittest.TestCase):
                                    [[15570.31111111,  3030.30666667,   171.04032   ,   190.13493333]]], results['out41'],precision=2)
 
     def test_check_modify_stream(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         in1 = Input('in1').last()
         par = Parameter('par', values=[[5]])
         add1 = in1 + par # 1 + 5 = 6
@@ -776,7 +789,7 @@ class ModelyPredictTest(unittest.TestCase):
         tot2 = add1 + in1 # 6 + 1 = 7
         out12 = Output('out12', tot1 + tot2) # = 24.2
         out2 = Output('out2', tot2) #= 7
-        test = Modely(visualizer=None)
+        test = Modely(visualizer=None,seed=1)
         test.addModel('out',[out1,out12,out2])
         test.neuralizeModel()
 
@@ -788,6 +801,7 @@ class ModelyPredictTest(unittest.TestCase):
 
 
     def test_parameter_and_linear(self):
+        NeuObj.clearNames()
         input = Input('in1').last()
         W15 = Parameter('W15', dimensions=(1, 5), values=[[[1,2,3,4,5]]])
         b15 = Parameter('b15', dimensions=5, values=[[1,2,3,4,5]])
@@ -826,6 +840,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((2, 1, 5), np.array(results['outWb']).shape)
         self.TestAlmostEqual([[[-7, 36, 51, 68, 89]],[[-5, 40, 57, 76, 99]]], results['outWb'])
 
+        NeuObj.clearNames()
         input2 = Input('in1').sw([-1,1])
         input42 = Input('in4', dimensions=4).sw([-1,1])
 
@@ -848,7 +863,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[[-7, 36, 51, 68, 89], [-5, 40, 57, 76, 99]]], results['outWb'])
 
     def test_initialization(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         input = Input('in1')
         W = Parameter('W', dimensions=(1,1), init=init_constant)
         b = Parameter('b', dimensions=1, init=init_constant)
@@ -878,7 +893,7 @@ class ModelyPredictTest(unittest.TestCase):
         outlin = Output('outlin', Fir(output_dimension=3,parameter_init=init_lin)(input.sw(2)))
         outlin2 = Output('outlin2', Fir(output_dimension=3,parameter_init=init_lin,parameter_init_params={'size_index':1, 'first_value':4, 'last_value':5})(input.sw(2)))
 
-        n = Modely(visualizer=None)
+        n = Modely(visualizer=None,seed=1)
         n.addModel('model',[o,o52,opar,opar2,ol,ol52,ofpar,ofpar2,outnegexp,outnegexp2,outexp,outexp2,outlin,outlin2])
         n.neuralizeModel()
         results = n({'in1': [1, 1, 2]})
@@ -918,6 +933,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[[8,9,10]],[[12,13.5,15.0]]], results['outlin2'])
 
     def test_sample_part_and_select(self):
+        NeuObj.clearNames()
         in1 = Input('in1')
         # Offset before the sample window
         with self.assertRaises(IndexError):
@@ -1048,6 +1064,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([1,1], results['in_SS3'])
 
     def test_time_part(self):
+        NeuObj.clearNames()
         in1 = Input('in1')
         # Offset before the time window
         with self.assertRaises(IndexError):
@@ -1154,6 +1171,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[-2, -1, 0], [-4, -3, 0]], results['in_TP1off3'])
     
     def test_part_and_select(self):
+        NeuObj.clearNames()
         in1 = Input('in1',dimensions=4)
 
         tw3, tw32 = in1.tw([-5, -2], offset=-4), in1.tw([0, 3], offset=0)
@@ -1256,6 +1274,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.TestAlmostEqual([[-1, 0, 2],[-2, 0, -6]], results['in_S4'])
 
     def test_predict_paramfun_param_const(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         pp = Parameter('pp', values=[[7],[8],[9]])
         ll = Constant('ll', values=[[12],[13],[14]])
@@ -1341,6 +1360,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual([[24.0, 24.0, 24.0]], results['out4'])
 
     def test_predict_fuzzify(self):
+        NeuObj.clearNames()
         input = Input('in1')
         fuzzi = Fuzzify(6, range=[0, 5], functions='Rectangular')(input.last())
         out = Output('out', fuzzi)
@@ -1352,6 +1372,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual([[[1.0, 0.0, 0.0, 0.0, 0.0, 0.0]],[[0.0, 1.0, 0.0, 0.0, 0.0, 0.0]],[[0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]], results['out'])
 
     def test_sw_on_stream_sw_by_heand(self):
+        NeuObj.clearNames()
         input = Input('in1')
         sw_from_input = input.sw(7)
 
@@ -1367,6 +1388,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((4, 3), np.array(results['out1']).shape)
         self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out1'])
 
+        NeuObj.clearNames()
         state = Input('state')
         out_aux = Output('out_aux', sw_from_input)
         out1 = Output('out1', state.sw(3))
@@ -1379,6 +1401,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out1'])
 
     def test_sw_on_stream_sw(self):
+        NeuObj.clearNames()
         input = Input('in1')
         sw_from_input = input.sw(7)
 
@@ -1391,6 +1414,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((4, 3), np.array(results['out1']).shape)
         self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out1'])
 
+        NeuObj.clearNames(['out1','out2'])
         out1 = Output('out1', sw_from_input.sw(3))
         out2 = Output('out2', sw_from_input.sw(8))
         with self.assertRaises(ValueError):
@@ -1409,6 +1433,7 @@ class ModelyPredictTest(unittest.TestCase):
                           [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]], results['out2'])
 
     def test_tw_on_stream_tw(self):
+        NeuObj.clearNames()
         input = Input('in1')
         tw_from_input = input.tw(3.5)
 
@@ -1421,8 +1446,8 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual((4, 3), np.array(results['out1']).shape)
         self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out1'])
 
-        out1 = Output('out1', tw_from_input.tw(1.5))
-        out2 = Output('out2', tw_from_input.tw(4))
+        out1 = Output('out11', tw_from_input.tw(1.5))
+        out2 = Output('out21', tw_from_input.tw(4))
         with self.assertRaises(ValueError):
             Output('out3', tw_from_input.tw(-1))
 
@@ -1430,15 +1455,16 @@ class ModelyPredictTest(unittest.TestCase):
         test.addModel('out_A', [out1,out2])
         test.neuralizeModel(0.5)
         results = test({'in1': [14, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
-        self.assertEqual((4, 3), np.array(results['out1']).shape)
-        self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out1'])
-        self.assertEqual((4, 8), np.array(results['out2']).shape)
+        self.assertEqual((4, 3), np.array(results['out11']).shape)
+        self.assertEqual([[4.0, 5.0, 6.0], [5.0, 6.0, 7.0], [6.0, 7.0, 8.0], [7.0, 8.0, 9.0]], results['out11'])
+        self.assertEqual((4, 8), np.array(results['out21']).shape)
         self.assertEqual([[0.0, 14.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
                           [14.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
                           [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-                          [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]], results['out2'])
+                          [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]], results['out21'])
 
     def test_sw_on_stream_sw_complex(self):
+        NeuObj.clearNames()
         input = Input('in1')
         state = State('state')
 
@@ -1485,6 +1511,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual(results['out41'], results['out42'])
 
     def test_sw_on_stream_tw_and_opposite(self):
+        NeuObj.clearNames()
         input = Input('in1')
 
         sw_3 = input.sw(3)
@@ -1517,6 +1544,7 @@ class ModelyPredictTest(unittest.TestCase):
                                                 [5, 6, 7, 8, 9, -3]])
 
     def test_sw_on_stream_sw_delay(self):
+        NeuObj.clearNames()
         input = Input('in1')
 
         sw_3 = input.sw(3)
@@ -1549,6 +1577,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual(results['out462'], [[0, 0, 0, 14], [0, 0, 14, 1], [0, 14, 1, 2], [14, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6], [4, 5, 6, 7]])
 
     def test_tw_on_stream_tw_delay(self):
+        NeuObj.clearNames()
         input = Input('in1')
 
         tw_3 = input.tw(1.5)
@@ -1581,6 +1610,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual(results['out462'], [[0, 0, 0, 14], [0, 0, 14, 1], [0, 14, 1, 2], [14, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6], [4, 5, 6, 7]])
 
     def test_z_on_stream_sw(self):
+        NeuObj.clearNames()
         input = Input('inin')
         sw_from_input = input.sw(5)
 
@@ -1603,6 +1633,7 @@ class ModelyPredictTest(unittest.TestCase):
                                  [4.0, 5.0, 6.0, 7.0, 8.0]], results['out2'])
 
     def test_delay_on_stream_tw(self):
+        NeuObj.clearNames()
         input = Input('inin')
         tw_from_input = input.tw(3.5)
 
@@ -1623,7 +1654,7 @@ class ModelyPredictTest(unittest.TestCase):
                                  [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]],  results['out1'])
 
     def test_localmodel(self):
-
+        NeuObj.clearNames()
         x = Input('x')
         F = Input('F')
         activationA = Fuzzify(2, [0, 1], functions='Triangular')(x.tw(1))
@@ -1709,6 +1740,7 @@ class ModelyPredictTest(unittest.TestCase):
         self.assertEqual(result['out_sum'],result['out'])
 
     def test_integrate_derivate(self):
+        NeuObj.clearNames()
         input = Input('in1')
 
         in1_s = Output('in1_s', input.s(1))

--- a/tests/test_model_predict_recurrent.py
+++ b/tests/test_model_predict_recurrent.py
@@ -3,10 +3,8 @@ import numpy as np
 
 from nnodely import *
 from nnodely.relation import NeuObj
-from nnodely import relation
-relation.CHECK_NAMES = False
-
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -55,6 +53,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_predict_and_states_values_fir_simple_closed_loop(self):
+        NeuObj.clearNames()
         x = Input('x')
         x_state = State('x_state')
         p = Parameter('p', dimensions=1, sw=1, values=[[1.0]])
@@ -79,6 +78,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual({'out': [0.0]}, result)
 
     def test_predict_values_fir_simple_closed_loop_predict(self):
+        NeuObj.clearNames()
         x = Input('x')
         x_in = Input('x_in')
         p = Parameter('p', dimensions=1, sw=1, values=[[1.0]])
@@ -97,6 +97,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual({'out': [0.0]}, result)
 
     def test_predict_values_fir_closed_loop(self):
+        NeuObj.clearNames()
         ## the memory is not shared between different calls
         x = Input('x')
         F = State('F')
@@ -134,6 +135,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out'], [16.0])
 
     def test_predict_values_fir_closed_loop_predict(self):
+        NeuObj.clearNames()
         ## the memory is not shared between different calls
         x = Input('x') 
         F = Input('F')
@@ -164,6 +166,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out'], [16.0])
 
     def test_predict_values_2fir_closed_loop(self):
+        NeuObj.clearNames()
         ## the memory is not shared between different calls
         x = State('x')
         y = State('y')
@@ -206,6 +209,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out_neg'], [-15.0, -20.0, -25.0])
 
     def test_predict_values_2fir_closed_loop_predict(self):
+        NeuObj.clearNames()
         ## the memory is not shared between different calls
         x = Input('x') 
         y = Input('y')
@@ -251,6 +255,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out_neg'], [-15.0, 1.0, 2.0])
 
     def test_predict_values_3states_closed_loop(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x') 
         F_state = State('F')
@@ -299,6 +304,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         #self.assertEqual(result['out'], [3.0, 6.0, 12.0, 20.0])
 
     def test_predict_values_3states_closed_loop_predict(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x')
         F_state = Input('F')
@@ -339,6 +345,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out'], [3.0,9.0,27.0,8.0])
 
     def test_predict_values_and_states_3states_more_window_closed_loop(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x') 
         y_state = State('y')
@@ -395,6 +402,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(test.states['z'].numpy().tolist(), [[[0.0], [0.0], [0.0], [0.0], [0.0]]])
 
     def test_predict_values_and_states_3states_more_window_closed_loop_predict(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x')
         y_state = Input('y')
@@ -435,6 +443,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out_z'], [45.0, 60.0, 234.0, 927.0, 3696.0])
 
     def test_predict_values_and_states_2states_more_window_connect(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x') 
         y_state = State('y')
@@ -513,6 +522,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(test.states['z'].numpy().tolist(), [[[0.0], [0.0], [0.0], [0.0], [0.0]]])
 
     def test_predict_values_and_states_2states_more_window_connect_predict(self):
+        NeuObj.clearNames()
         ## the state is saved inside the model so the memory is shared between different calls
         x = Input('x')
         y_state = Input('y')
@@ -562,6 +572,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         self.assertEqual(result['out'], [sum(x) for x in zip(result['out_x'],result['out_y'],result['out_z'])])
 
     def test_predict_values_and_connect_variables_2models_more_window_connect(self):
+        NeuObj.clearNames()
         ## Model1
         input1 = Input('in1')
         a = Parameter('a', dimensions=1, tw=0.05, values=[[1],[1],[1],[1],[1]])
@@ -634,6 +645,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         # self.assertEqual(test.model.states['in3'].detach().numpy().tolist(), [[[5.], [30.], [4.]]])
 
     def test_predict_values_and_connect_variables_2models_more_window_connect_predict(self):
+        NeuObj.clearNames()
         ## Model1
         input1 = Input('in1')
         a = Parameter('a', dimensions=1, tw=0.05, values=[[1],[1],[1],[1],[1]])
@@ -703,6 +715,7 @@ class ModelyRecurrentPredictTest(unittest.TestCase):
         # self.assertEqual(test.model.connect_variables['in3'].detach().numpy().tolist(), [[[5.], [30.], [4.]]])
 
     def test_predict_values_and_states_only_state_variables_more_window_closed_loop(self):
+        NeuObj.clearNames()
         x_state = State('x_state')
         p = Parameter('p', dimensions=1, tw=0.03, values=[[1.0], [1.0], [1.0]])
         rel_x = Fir(parameter=p)(x_state.tw(0.03))

--- a/tests/test_network_element.py
+++ b/tests/test_network_element.py
@@ -1,12 +1,11 @@
 import unittest, sys, os, torch
 
-from nnodely import *
-from nnodely.relation import Stream
-from nnodely import relation
 import numpy as np
-relation.CHECK_NAMES = False
 
+from nnodely import *
+from nnodely.relation import NeuObj, Stream
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -27,7 +26,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_network_building_very_simple(self):
-
+        NeuObj.clearNames()
         input1 = Input('in1').last()
         rel1 = Fir(input1)
         fun = Output('out', rel1)
@@ -41,6 +40,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[ind],list(value.weights.shape))
       
     def test_network_building_simple(self):
+        NeuObj.clearNames()
         Stream.resetCount()
         input1 = Input('in1')
         rel1 = Fir(input1.tw(0.05))
@@ -56,6 +56,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[key],list(value.weights.shape))
 
     def test_network_building_tw(self):
+        NeuObj.clearNames()
         Stream.resetCount()
         input1 = Input('in1')
         input2 = Input('in2')
@@ -75,6 +76,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
     
     def test_network_building_tw2(self):
         Stream.resetCount()
+        NeuObj.clearNames()
         input2 = Input('in2')
         rel3 = Fir(input2.tw(0.05))
         rel4 = Fir(input2.tw([-0.02,0.02]))
@@ -95,6 +97,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[key],list(value.weights.shape))
 
     def test_network_building_tw3(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         rel3 = Fir(input2.tw(0.05))
         rel4 = Fir(input2.tw([-0.01,0.03]))
@@ -110,6 +113,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[ind],list(value.weights.shape))
 
     def test_network_building_tw_with_offest(self):
+        NeuObj.clearNames()
         Stream.resetCount()
         input2 = Input('in2')
         rel3 = Fir(input2.tw(0.05))
@@ -128,6 +132,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[key],list(value.weights.shape))
 
     def test_network_building_tw_negative(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         rel1 = Fir(input2.tw([-0.04,-0.01]))
         rel2 = Fir(input2.tw([-0.06,-0.03]))
@@ -142,6 +147,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[ind],list(value.weights.shape))
 
     def test_network_building_tw_positive(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         rel1 = Fir(input2.tw([0.01,0.04]))
         rel2 = Fir(input2.tw([0.03,0.06]))
@@ -157,6 +163,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
 
     def test_network_building_sw_with_offset(self):
         Stream.resetCount()
+        NeuObj.clearNames()
         input2 = Input('in2')
         rel3 = Fir(input2.sw(5))
         rel4 = Fir(input2.sw([-4,2]))
@@ -173,6 +180,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[key],list(value.weights.shape))
 
     def test_network_building_sw_and_tw(self):
+        NeuObj.clearNames()
         input2 = Input('in2')
         with self.assertRaises(ValueError):
             input2.sw(5)+input2.tw(0.05)
@@ -189,7 +197,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[ind],list(value.weights.shape))
 
     def test_network_linear(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         input = Input('in1')
         rel1 = Linear(input.sw([-4,2]))
         rel2 = Linear(5)(input.sw([-1, 2]))
@@ -202,7 +210,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         fun15 = Output('out51',rel15)
         fun25 = Output('out52', rel25)
 
-        test = Modely(visualizer=None)
+        test = Modely(seed =1, visualizer=None)
         test.addModel('fun',[fun1,fun2,fun15,fun25])
         test.neuralizeModel(0.01)
 
@@ -211,13 +219,13 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
             self.assertEqual(list_of_dimensions[ind],list(value.weights.shape))
 
     def test_network_linear_interpolation_train(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         x = Input('x')
         param = Parameter(name='a', sw=1)
         rel1 = Fir(parameter=param)(Interpolation(x_points=[1.0, 2.0, 3.0, 4.0],y_points=[2.0, 4.0, 6.0, 8.0], mode='linear')(x.last()))
         out = Output('out',rel1)
 
-        test = Modely(visualizer=None)
+        test = Modely(seed = 1, visualizer=None)
         test.addModel('fun',[out])
         test.addMinimize('error', out, x.last())
         test.neuralizeModel(0.01)
@@ -228,32 +236,32 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         self.assertAlmostEqual(test.model.all_parameters['a'].item(), 0.5, places=2)
 
     def test_network_linear_interpolation(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
+
         x = Input('x')
         rel1 = Interpolation(x_points=[1.0, 2.0, 3.0, 4.0],y_points=[1.0, 4.0, 9.0, 16.0], mode='linear')(x.last())
         out = Output('out',rel1)
 
-        test = Modely(visualizer=None)
+        test = Modely(seed=1,visualizer=None)
         test.addModel('fun',[out])
         test.neuralizeModel(0.01)
 
         inference = test(inputs={'x':[1.5,2.5,3.5]})
         self.assertEqual(inference['out'],[2.5,6.5,12.5])
 
-        torch.manual_seed(1)
-        x = Input('x')
-        rel1 = Interpolation(x_points=[1.0, 4.0, 3.0, 2.0],y_points=[1.0, 16.0, 9.0, 4.0], mode='linear')(x.last())
-        out = Output('out',rel1)
+        x1 = Input('x1')
+        rel1 = Interpolation(x_points=[1.0, 4.0, 3.0, 2.0],y_points=[1.0, 16.0, 9.0, 4.0], mode='linear')(x1.last())
+        out = Output('out1',rel1)
 
         test = Modely(visualizer=None)
         test.addModel('fun',[out])
         test.neuralizeModel(0.01)
 
-        inference = test(inputs={'x':[1.5,2.5,3.5]})
-        self.assertEqual(inference['out'],[2.5,6.5,12.5])
+        inference = test(inputs={'x1':[1.5,2.5,3.5]})
+        self.assertEqual(inference['out1'],[2.5,6.5,12.5])
 
     def test_softmax_and_sigmoid(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         x = Input('x')
         y = Input('y', dimensions=3)
         softmax = Softmax(y.last())
@@ -303,7 +311,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         self.TestAlmostEqual([[[27.3082332611084, 1.5430806875228882, 1.0, 201.71563720703125, 3.762195587158203]]], result['cosh_out_3'])
 
     def test_concatenate_time_concatenate(self):
-        torch.manual_seed(1)
+        NeuObj.clearNames()
         input = Input('in1')
         input2 = Input('in2')
         concatenate_rel = Concatenate(input.last(),input2.last())
@@ -328,7 +336,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         out7 = Output('concatenate_tw_5', concatenate_tw_rel_5)
         out8 = Output('time_concatenate_tw_5', timeconcatenate_tw_rel_5)
 
-        test = Modely(visualizer=None)
+        test = Modely(seed=1,visualizer=None)
         test.addModel('model',[out1,out2,out3,out4,out5,out6,out7,out8])
         test.neuralizeModel(1)
 
@@ -360,6 +368,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
                            [32.0, 33.0, 34.0, 35.0, 36.0]]], result['time_concatenate_tw_5'])
 
     def test_equation_learner(self):
+        NeuObj.clearNames()
         x = Input('x')
         F = Input('F')
 
@@ -423,6 +432,7 @@ class ModelyNetworkBuildingTest(unittest.TestCase):
         self.assertEqual(result['el3_multi_tw'], [[[20.0, 8.0, 0.0, 0.0, 0.0, 1.0], [30.0, 12.0, 0.0, 0.0, 0.0, 1.0]]])
 
     def test_localmodel(self):
+        NeuObj.clearNames()
         x = Input('x')
         activationA = Fuzzify(2, [0, 1], functions='Triangular')(x.last())
         loc = LocalModel(input_function=Fir())(x.tw(1), activationA)

--- a/tests/test_parameters_of_train.py
+++ b/tests/test_parameters_of_train.py
@@ -2,10 +2,9 @@ import unittest, os, sys
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -36,6 +35,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_network_mass_spring_damper(self):
+        NeuObj.clearNames()
         x = Input('x')  # Position
         F = Input('F')  # Force
 
@@ -68,6 +68,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(0.001,test.run_training_params['optimizer_defaults']['lr'])
 
     def test_build_dataset_batch_connect(self):
+        NeuObj.clearNames()
         data_x = np.random.rand(500) * 20 - 10
         data_a = 2
         data_b = -3
@@ -116,6 +117,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(1, test.run_training_params['unused_samples'])
 
     def test_recurrent_train_closed_loop(self):
+        NeuObj.clearNames()
         data_x = np.random.rand(500) * 20 - 10
         data_a = 2
         data_b = -3
@@ -164,6 +166,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size - prediction_samples, test.run_training_params['unused_samples'])
 
     def test_recurrent_train_single_close_loop(self):
+        NeuObj.clearNames()
         data_x = np.array(list(range(1, 101, 1)), dtype=np.float32)
         dataset = {'x': data_x, 'y': 2 * data_x}
 
@@ -304,6 +307,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_build_dataset_batch2(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -347,6 +351,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_build_dataset_batch3(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -393,6 +398,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_build_dataset_batch4(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -439,6 +445,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_build_dataset_from_code(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         output = Input('out')
         rel1 = Fir(input1.tw(0.05))
@@ -490,6 +497,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_network_multi_dataset(self):
+        NeuObj.clearNames()
         train_folder = os.path.join(os.path.dirname(__file__), 'data/')
         val_folder = os.path.join(os.path.dirname(__file__), 'val_data/')
         test_folder = os.path.join(os.path.dirname(__file__), 'test_data/')
@@ -546,6 +554,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_train_vector_input(self):
+        NeuObj.clearNames()
         x = Input('x', dimensions=4)
         y = Input('y', dimensions=3)
         k = Input('k', dimensions=2)
@@ -609,6 +618,7 @@ class ModelyTrainingTestParameter(unittest.TestCase):
         self.assertEqual(n_samples - list_of_batch_indexes[-1] - batch_size, test.run_training_params['unused_samples'])
 
     def test_optimizer_configuration(self):
+        NeuObj.clearNames()
         ## Model1
         input1 = Input('in1')
         a = Parameter('a', dimensions=1, tw=0.05, values=[[1], [1], [1], [1], [1]])

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -2,10 +2,9 @@ import unittest, os, sys
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -29,6 +28,7 @@ class ModelyTrainingTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_analysis_results(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         target1 = Input('out1')
         target2 = Input('out2')
@@ -96,6 +96,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.assertAlmostEqual(((1.0 ** 2) * 8.0 / 10.0 * 0.5 + 0.0)/2.0, test.performance['dataset2']['total']['mean_error'], places=6)
 
     def test_analysis_results_closed_loop_state(self):
+        NeuObj.clearNames()
         input1 = State('in1')
         target1 = Input('out1')
         target2 = Input('out2')
@@ -207,6 +208,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.assertAlmostEqual((np.sum((np.array(A).flatten()-np.array(B).flatten())**2)/30.0+np.sum((np.array(C).flatten()-np.array(B).flatten())**2)/30.0)/2.0, test.performance['dataset']['total']['mean_error'], places=3)
 
     def test_analysis_results_closed_loop(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         target1 = Input('out1')
         target2 = Input('out2')

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,10 +3,8 @@ import numpy as np
 
 from nnodely import *
 from nnodely.relation import NeuObj
-from nnodely import relation
-relation.CHECK_NAMES = False
-
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -28,6 +26,7 @@ class ModelyTrainingTest(unittest.TestCase):
             self.assertAlmostEqual(data1, data2, places=precision)
 
     def test_training_values_fir(self):
+        NeuObj.clearNames()
         input1 = Input('in1')
         target = Input('out1')
         a = Parameter('a', values=[[1]])
@@ -121,6 +120,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.assertListEqual([[-51.0]], test.model.all_parameters['a'].data.numpy().tolist())
 
     def test_network_linear_interpolation_train(self):
+        NeuObj.clearNames()
         x = Input('x')
         param = Parameter(name='a', sw=1)
         rel1 = Fir(parameter=param)(Interpolation(x_points=[1.0, 2.0, 3.0, 4.0],y_points=[2.0, 4.0, 6.0, 8.0], mode='linear')(x.last()))
@@ -137,6 +137,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.assertAlmostEqual(test.model.all_parameters['a'].item(), 0.5, places=2)
 
     def test_multimodel_with_loss_gain_and_lr_gain(self):
+        NeuObj.clearNames()
         ## Model1
         input1 = Input('in1')
         a1 = Parameter('a1', dimensions=1, tw=0.05, values=[[1],[1],[1],[1],[1]])
@@ -239,6 +240,7 @@ class ModelyTrainingTest(unittest.TestCase):
         self.assertListEqual(test.model.all_parameters['b3'].data.numpy().tolist(), [[-5],[-5],[-5],[-5],[-5]])
 
     def test_train_equation_learner(self):
+        NeuObj.clearNames()
         def func(x):
             return np.cos(x) + np.sin(x)
         

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,8 @@ import unittest, os, sys, torch
 
 from nnodely import *
 from nnodely.utils import linear_interp
-
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -2,10 +2,9 @@ import sys, os, unittest, torch, shutil
 import numpy as np
 
 from nnodely import *
-from nnodely import relation
-relation.CHECK_NAMES = False
-
+from nnodely.relation import NeuObj
 from nnodely.logger import logging, nnLogger
+
 log = nnLogger(__name__, logging.CRITICAL)
 log.setAllLevel(logging.CRITICAL)
 
@@ -16,6 +15,7 @@ sys.path.append(os.getcwd())
 
 class ModelyTestVisualizer(unittest.TestCase):
     def __init__(self, *args, **kwargs):
+        NeuObj.clearNames()
         super(ModelyTestVisualizer, self).__init__(*args, **kwargs)
 
         self.x = x = Input('x')


### PR DESCRIPTION
We fixed the problem of unique names for timeoperation on stream and added all the righthand side aritmetic operation. 